### PR TITLE
Enable ForceLoadAsMod for server compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ jar {
         attributes(
                 "FMLCorePlugin": "cx.rain.mc.forgemod.practicaladjustments.coremod.PracticalAdjustmentsPlugin",
                 "FMLCorePluginContainsFMLMod": true,
+                "ForceLoadAsMod": true,
                 "TweakClass": "org.spongepowered.asm.launch.MixinTweaker",
                 "TweakOrder": 0,
                 "MixinConfigs": "mixins.practicaladjustments.json"


### PR DESCRIPTION
Server detects mod as duplicate (DuplicateModsFoundException) when the option is not set.